### PR TITLE
add nestjs service unit test snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Nest NestModule                         | n-module-nest                 | NestJS
 Nest Mongoose Service                   | n-mongoose-service            | NestJS Service for Mongoose                                   | 
 Nest Mongoose Interface                 | n-mongoose-interface          | NestJS Interface for mongoose                                 | 
 Nest Unit Test                          | n-test                        | NestJS Unit Test                                              | 
+Nest Service Unit Test                  | n-test-service                | NestJS Service Unit Test                                      | 
 Nest Sequelize Entity                   | n-sequelize-entity            | NestJS Sequelize Entity                                       | 
 Nest Sequelize Provider                 | n-sequelize-provider          | NestJS Sequelize Provider                                     | 
 Nest Sequelize Database Provider        | n-sequelize-database-provider | NestJS Sequelize Provider                                     | 
@@ -61,9 +62,6 @@ Contributions are highly welcome
 
 ## Release Notes
 
-## 1.2.0 - 20-03-2019
+## 1.1.0 - 16-08-2018
 
-- added snippet for typeorm
-Thanks to [@ahmedNY](https://github.com/ahmedNY)
-
- 
+- added snippet for pipes

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -142,6 +142,30 @@
       "});"
     ]
   },
+   "Nest-Service-Unit-Test": {
+    "prefix": "n-test-service",
+    "description": "Nest Service Unit Test",
+    "body": [
+      "import { Test } from '@nestjs/testing';",
+      "import { ${1}Service } from './${2}.service';",
+      "",
+      "describe('${1} Test suite', () => {",
+      "\tlet ${2}Service: ${1}Service;",
+      "",
+      "\tbeforeEach(async () => {",
+      "\t\tconst module = await Test.createTestingModule({",
+      "\t\t\tproviders: [${1}Service],",
+      "\t\t}).compile();",
+      "",
+      "\t\t${2}Service = module.get<${1}Service>(${1}Service);",
+      "\t});",
+      "",
+      "\tit('should be defined', () => {",
+        "\t\texpect(${2}Service).toBeDefined();",
+      "\t});",
+      "});"
+    ]
+  },
   "Nest Sequelize Entity": {
     "prefix": "n-sequelize-entity",
     "description": "NestJS Sequelize Entity",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -142,9 +142,9 @@
       "});"
     ]
   },
-   "Nest-Service-Unit-Test": {
+   "Nest Service Unit Test": {
     "prefix": "n-test-service",
-    "description": "Nest Service Unit Test",
+    "description": "NestJS Service Unit Test",
     "body": [
       "import { Test } from '@nestjs/testing';",
       "import { ${1}Service } from './${2}.service';",


### PR DESCRIPTION
## Purpose
* I find myself usually writing unit tests for services, the default snippet has also the controller and this kind of slows me down because after I need to delete the controller from the test.

## What
*  add simple unit test for services only

## How to Test
* try `n-test-service`, the output should be 
```ts
import { Test } from '@nestjs/testing';
import { Service } from './.service';

describe(' Test suite', () => {
    let Service: Service;

    beforeEach(async () => {
        const module = await Test.createTestingModule({
            providers: [Service],
        }).compile();

        Service = module.get<Service>(Service);
    });

    it('should be defined', () => {
        expect(Service).toBeDefined();
    });
});
```

## What to Check
Verify that the following are valid
* try `n-test-service`